### PR TITLE
Fix code injection in footer on settings save

### DIFF
--- a/layouts/partials/goatcounter.html
+++ b/layouts/partials/goatcounter.html
@@ -2,11 +2,14 @@
 {{ if .Site.Params.use_javascript }}
 {{- /* JavaScript-basiertes Tracking mit lokalem GoatCounter JS */ -}}
 <script data-goatcounter="{{ .Site.Params.goatcounter_url }}/count" src="{{ "js/count.js" | relURL }}" async></script>
-{{ end }}
-{{- /* Fallback für Browser ohne JavaScript oder wenn JS deaktiviert ist */ -}}
+{{- /* Fallback für Browser ohne JavaScript */ -}}
 <noscript>
   <img src="{{ .Site.Params.goatcounter_url }}/count?p={{ .RelPermalink }}&t={{ .Title | urlquery }}" alt="" style="position:absolute;bottom:0;width:1px;height:1px">
 </noscript>
+{{ else }}
+{{- /* Pixel-basiertes Tracking (kein JavaScript) */ -}}
+<img src="{{ .Site.Params.goatcounter_url }}/count?p={{ .RelPermalink }}&t={{ .Title | urlquery }}" alt="" style="position:absolute;bottom:0;width:1px;height:1px">
+{{ end }}
 {{ else }}
 <!-- GoatCounter plugin installed, but no domain configured -->
 {{ end }}


### PR DESCRIPTION
When use_javascript setting is false, the tracking pixel was wrapped in a <noscript> tag, which only displays when JavaScript is disabled in the browser. This meant that users with JavaScript enabled but the setting disabled would not be tracked at all.

Changes:
- Move noscript fallback inside use_javascript conditional block
- Add pixel-based tracking as else branch when JavaScript tracking is disabled
- Now pixel tracking works correctly regardless of browser JavaScript setting

Fixes the issue where saving settings with use_javascript=false resulted in no tracking code being injected into the footer.